### PR TITLE
feat: allow target to be set rather than reading from API key

### DIFF
--- a/.changes/unreleased/Added-20250327-103240.yaml
+++ b/.changes/unreleased/Added-20250327-103240.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Allow setting of `organization` on provider and passing of `project` and `target` to explicitly set a target rather than getting it from the hive key.
+time: 2025-03-27T10:32:40.614834807+01:00

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,8 +33,9 @@ type HiveProvider struct {
 
 // HiveProviderModel describes the provider data model.
 type HiveProviderModel struct {
-	Endpoint types.String `tfsdk:"endpoint"`
-	Token    types.String `tfsdk:"token"`
+	Endpoint     types.String `tfsdk:"endpoint"`
+	Token        types.String `tfsdk:"token"`
+	Organization types.String `tfsdk:"organization"`
 }
 
 func (p *HiveProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -53,6 +54,10 @@ func (p *HiveProvider) Schema(ctx context.Context, req provider.SchemaRequest, r
 				MarkdownDescription: "The token to authenticate with the registry",
 				Required:            true,
 				Sensitive:           true,
+			},
+			"organization": schema.StringAttribute{
+				MarkdownDescription: "The organization within the registry",
+				Optional:            true,
 			},
 		},
 	}
@@ -81,7 +86,7 @@ func (p *HiveProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	httpClient := &http.Client{
 		Transport: sdk.NewDebugTransport(http.DefaultTransport),
 	}
-	client := sdk.NewHiveClient(httpClient, endpoint, token)
+	client := sdk.NewHiveClient(httpClient, endpoint, data.Organization.ValueString(), token)
 
 	resp.DataSourceData = client
 	resp.ResourceData = client

--- a/internal/provider/resource_schema_check.go
+++ b/internal/provider/resource_schema_check.go
@@ -37,6 +37,8 @@ type HiveSchemaCheckResourceModel struct {
 	Schema    types.String `tfsdk:"schema"`
 	ContextId types.String `tfsdk:"context_id"`
 	Id        types.String `tfsdk:"id"`
+	Target	  types.String `tfsdk:"target"`
+	Project	  types.String `tfsdk:"target"`
 }
 
 // Metadata returns the resource type name.
@@ -81,6 +83,20 @@ func (r *HiveSchemaCheckResource) Schema(ctx context.Context, req resource.Schem
 			"context_id": schema.StringAttribute{
 				MarkdownDescription: "Context ID allows retaining approved breaking changes with the lifecycle",
 				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"project": schema.StringAttribute{
+				MarkdownDescription: "The project name",
+				Optional: 		  	  true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"target": schema.StringAttribute{
+				MarkdownDescription: "The target name",
+				Optional: 		  	  true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -184,6 +200,8 @@ func (r *HiveSchemaCheckResource) ExecuteRequest(ctx context.Context, data *Hive
 		Commit:    data.Commit.ValueString(),
 		Author:    data.Author.ValueString(),
 		ContextId: data.ContextId.ValueString(),
+		Target:    data.Target.ValueString(),
+		Project:   data.Project.ValueString(),
 	})
 
 	if err != nil {

--- a/internal/provider/resource_schema_publish.go
+++ b/internal/provider/resource_schema_publish.go
@@ -37,6 +37,8 @@ type HiveSchemaPublishResourceModel struct {
 	Schema  types.String `tfsdk:"schema"`
 	URL     types.String `tfsdk:"url"`
 	Id      types.String `tfsdk:"id"`
+	Project types.String `tfsdk:"project"`
+	Target  types.String `tfsdk:"target"`
 }
 
 // Metadata returns the resource type name.
@@ -81,6 +83,20 @@ func (r *HiveSchemaPublishResource) Schema(ctx context.Context, req resource.Sch
 			"url": schema.StringAttribute{
 				MarkdownDescription: "The GraphQL schema content",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"project": schema.StringAttribute{
+				MarkdownDescription: "The project name",
+				Optional: 		  	  true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"target": schema.StringAttribute{
+				MarkdownDescription: "The target name",
+				Optional: 		  	  true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -184,6 +200,8 @@ func (r *HiveSchemaPublishResource) ExecuteRequest(ctx context.Context, data *Hi
 		Commit:  data.Commit.ValueString(),
 		Author:  data.Author.ValueString(),
 		URL:     data.URL.ValueString(),
+		Project: data.Project.ValueString(),
+		Target:  data.Target.ValueString(),
 	})
 
 	if err != nil {

--- a/internal/sdk/client.go
+++ b/internal/sdk/client.go
@@ -20,13 +20,14 @@ func (hrt *HiveRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	return hrt.rt.RoundTrip(req)
 }
 
-// HiveClient encapsulates an HTTP client, a GraphQL endpoint, and an API token.
+// HiveClient encapsulates an HTTP client, a GraphQL endpoint, an API token and an optional Organization string.
 type HiveClient struct {
 	client *graphql.Client
+	Organization string
 }
 
 // NewHiveClient creates a new HiveClient instance.
-func NewHiveClient(client *http.Client, endpoint, token string) *HiveClient {
+func NewHiveClient(client *http.Client, endpoint, organization string, token string) *HiveClient {
 	client.Transport = &HiveRoundTripper{
 		rt:        client.Transport,
 		authToken: token,
@@ -37,5 +38,6 @@ func NewHiveClient(client *http.Client, endpoint, token string) *HiveClient {
 
 	return &HiveClient{
 		client: &gqlClient,
+		Organization: organization,
 	}
 }

--- a/internal/sdk/schema_check.go
+++ b/internal/sdk/schema_check.go
@@ -15,6 +15,8 @@ type SchemaCheckInput struct {
 	Author    string
 	Commit    string
 	ContextId string
+	Target    string
+	Project   string
 }
 
 type SchemaCheckResult struct {
@@ -24,10 +26,12 @@ type SchemaCheckResult struct {
 }
 
 func (hc *HiveClient) SchemaCheck(ctx context.Context, input *SchemaCheckInput) (*SchemaCheckResult, error) {
+
 	meta := &client.SchemaCheckMetaInput{
 		Author: input.Author,
 		Commit: input.Commit,
 	}
+
 
 	if meta.Author == "" || meta.Commit == "" {
 		gitInfo, err := GetLatestCommitInfo()
@@ -47,13 +51,7 @@ func (hc *HiveClient) SchemaCheck(ctx context.Context, input *SchemaCheckInput) 
 		Sdl:       minifySchema(input.Schema),
 		Meta:      meta,
 		ContextId: input.ContextId,
-		// Target: client.TargetReferenceInput{
-		// 	BySelector: client.TargetSelectorInput{
-		// 		OrganizationSlug: "..",
-		// 		ProjectSlug:      "michael-sandbox",
-		// 		TargetSlug:       "development",
-		// 	},
-		// },
+		Target:    getTarget(ctx, hc.Organization, input.Project, input.Target),
 	}
 
 	data, err := client.SchemaCheck(ctx, *hc.client, vars)

--- a/internal/sdk/schema_publish.go
+++ b/internal/sdk/schema_publish.go
@@ -17,6 +17,8 @@ type SchemaPublishInput struct {
 	URL     string
 	Author  string
 	Commit  string
+	Target 	string
+	Project string
 }
 
 type SchemaPublishResult struct {
@@ -33,6 +35,7 @@ func (hc *HiveClient) SchemaPublish(ctx context.Context, input *SchemaPublishInp
 		Author:  input.Author,
 		Sdl:     minifySchema(input.Schema),
 		Url:     input.URL,
+		Target:  getTarget(ctx, hc.Organization, input.Project, input.Target),
 	}
 
 	// Try to get the latest commit info from git if it's not provided.

--- a/internal/sdk/utils.go
+++ b/internal/sdk/utils.go
@@ -1,12 +1,29 @@
 package sdk
 
 import (
+	"context"
 	"regexp"
 	"strings"
+
+	"github.com/labd/terraform-provider-hive/internal/client"
 )
 
 // minifySchema removes extra whitespace from the schema string.
 func minifySchema(schema string) string {
 	re := regexp.MustCompile(`\s+`)
 	return strings.TrimSpace(re.ReplaceAllString(schema, " "))
+}
+
+func getTarget(ctx context.Context, organization string, project string, target string) (*client.TargetReferenceInput)  {
+	if organization == "" || project == "" || target == "" {
+        return nil
+    }
+
+	return &client.TargetReferenceInput{
+		BySelector: client.TargetSelectorInput{
+			OrganizationSlug: organization,
+			ProjectSlug:      project,
+			TargetSlug:       target,
+		},
+	}
 }


### PR DESCRIPTION
Add `target` to schema check and schema publish to allow keys with global scope to be used.
Organization can now be set through the provider level, while project and target can be set at the resource level.